### PR TITLE
readd omitted 'default' keyword & README refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@
 > - Fork by @yasemincidem who added the real cross platform behavior and datepicker [react-native-wheel-scroll-picker](https://github.com/yasemincidem/react-native-picker-scrollview).
 > - This is the third fork of repository, since it seems that @yasemincidem is no longer supporting [react-native-wheel-scroll-picker](https://github.com/yasemincidem/react-native-picker-scrollview).
 
- ---
- 
- ## Table of Contents
+---
 
-1. [Features](#features)
-2. [Installation](#installation)
-3. [Usage](#usage)
-   - [Example](#usage)
-4. [Props](#props)
-5. [License](#license)
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Props](#props)
+- [Author](#author)
+- [License](#license)
 
 ## Installation
 
@@ -34,14 +34,14 @@ npm install react-native-wheel-scrollview-picker --save
 ## Usage
 
 ```jsx
-import React, { Component } from "react";
-import ScrollPicker from "react-native-wheel-scroll-picker";
+import React, { Component } from 'react';
+import ScrollPicker from 'react-native-wheel-scrollview-picker';
 
 export default class SimpleExample extends Component {
   render() {
     return (
       <ScrollPicker
-        dataSource={["1", "2", "3", "4", "5", "6"]}
+        dataSource={['1', '2', '3', '4', '5', '6']}
         selectedIndex={1}
         renderItem={(data, index) => {
           //
@@ -51,9 +51,9 @@ export default class SimpleExample extends Component {
         }}
         wrapperHeight={180}
         wrapperWidth={150}
-        wrapperBackground={"#FFFFFF"}
+        wrapperBackground={'#FFFFFF'}
         itemHeight={60}
-        highlightColor={"#d8d8d8"}
+        highlightColor={'#d8d8d8'}
         highlightBorderWidth={2}
       />
     );
@@ -63,18 +63,18 @@ export default class SimpleExample extends Component {
 
 ## Props
 
-| Props                |                                                                                                      Description                                                                                                       |   Type   |  Default |
-| -------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------: | -------: |
-| dataSource           |                                                                        Data of the picker                                                                          | Array|          |
-| selectedIndex      |                                                                 selected index of the item                                                                  |  number  |        1 |
-| wrapperHeight               |                                                                                       height of the picker                                                                                        | number  |    |
-| wrapperWidth |                                                                           width of the picker                                                                            |  number  |          |
-| wrapperBackground      |                                                                                       picker background                                                                                       | string  |    '#FFF'|
-| itemHeight         | height of eacch item |  number  |      |
-| highlightColor      |                                                                   color of the indicator line                                                                   |   number   | 1 |
-| highlightBorderWidth          |                                 width of the indicator                                 |  string  |     "#d8d8d8"     |
-| activeItemTextStyle            |                                 Active Item Text object style                                  |  object |          |
-| itemTextStyle | Item Text object style | object | |
+| Props                |          Description          |  Type  |   Default |
+| -------------------- | :---------------------------: | :----: | --------: |
+| dataSource           |      Data of the picker       | Array  |           |
+| selectedIndex        |  selected index of the item   | number |         1 |
+| wrapperHeight        |     height of the picker      | number |           |
+| wrapperWidth         |      width of the picker      | number |           |
+| wrapperBackground    |       picker background       | string |    '#FFF' |
+| itemHeight           |      height of each item      | number |           |
+| highlightColor       |  color of the indicator line  | number |         1 |
+| highlightBorderWidth |    width of the indicator     | string | "#d8d8d8" |
+| activeItemTextStyle  | Active Item Text object style | object |           |
+| itemTextStyle        |    Item Text object style     | object |           |
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@
 ---
 
 ## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Props](#props)
-- [Author](#author)
-- [License](#license)
+1. [Features](#features)
+2. [Installation](#installation)
+3. [Usage](#usage)
+   - [Example](#usage)
+4. [Props](#props)
+5. [License](#license)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ export default class SimpleExample extends Component {
         }}
         wrapperHeight={180}
         wrapperWidth={150}
-        wrapperBackground={'#FFFFFF'}
+        wrapperBackground='#FFFFFF'
         itemHeight={60}
-        highlightColor={'#d8d8d8'}
+        highlightColor='#d8d8d8'
         highlightBorderWidth={2}
       />
     );

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const isViewStyle = (style) => {
         style !== null &&
         Object.keys(style).includes("height"));
 };
-export function ScrollPicker({ itemHeight = 30, style, ...props }) {
+export default function ScrollPicker({ itemHeight = 30, style, ...props }) {
     const [initialized, setInitialized] = useState(false);
     const [selectedIndex, setSelectedIndex] = useState(props.selectedIndex && props.selectedIndex >= 0 ? props.selectedIndex : 0);
     const sView = useRef(null);

--- a/index.tsx
+++ b/index.tsx
@@ -51,7 +51,7 @@ export type ScrollPickerProps = {
   wrapperColor?: string;
 };
 
-export function ScrollPicker({
+export default function ScrollPicker({
   itemHeight = 30,
   style,
   ...props


### PR DESCRIPTION
### Fixed 
- `index.js` `index.tsx`
    - The last Pull Request omitted the `default` keyword, which caused `Element Type Error` when imported like the example.
- `README.md`
    - In the example, the package name for the `import` statement was wrong
    - Fixed ESLint error from the example
    - Fixed typo _eacch_
    - Ran Prettier to make the file readable even in raw